### PR TITLE
adding settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name='xframeoptions'


### PR DESCRIPTION
with `rootProject.name` set, so that the plugin will be at the coordinate stated in the documentation:

`runtime('org.grails.plugins:xframeoptions:1.1.0')` instead of now `runtime('org.grails.plugins:grails-x-frame-options-plugin:1.1.0')`